### PR TITLE
add context propagation to storage operations

### DIFF
--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -231,7 +231,7 @@ func (p *v1Provider) ListEvents(res http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		return
 	}
-	events, total, err := hermes.GetEvents(&filter, indexID, p.storage)
+	events, total, err := hermes.GetEvents(req.Context(), &filter, indexID, p.storage)
 	if respondwith.ErrorText(res, err) {
 		logg.Error("api.ListEvents: error calling hermes.GetEvents(): %s", err.Error())
 
@@ -291,7 +291,7 @@ func (p *v1Provider) GetEventDetails(res http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	event, err := hermes.GetEvent(eventID, indexID, p.storage)
+	event, err := hermes.GetEvent(req.Context(), eventID, indexID, p.storage)
 
 	if respondwith.ErrorText(res, err) {
 		logg.Error("error getting events from Storage: %s", err)
@@ -341,7 +341,7 @@ func (p *v1Provider) GetAttributes(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	attribute, err := hermes.GetAttributes(&filter, indexID, p.storage)
+	attribute, err := hermes.GetAttributes(req.Context(), &filter, indexID, p.storage)
 
 	if respondwith.ErrorText(res, err) {
 		logg.Error("could not get attributes from Storage: %s", err)

--- a/pkg/hermes/events.go
+++ b/pkg/hermes/events.go
@@ -4,6 +4,7 @@
 package hermes
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jinzhu/copier"
@@ -68,14 +69,14 @@ type AttributeFilter struct {
 }
 
 // GetEvents returns a list of matching events (with filtering)
-func GetEvents(filter *EventFilter, tenantID string, eventStore storage.Storage) ([]*ListEvent, int, error) {
+func GetEvents(ctx context.Context, filter *EventFilter, tenantID string, eventStore storage.Storage) ([]*ListEvent, int, error) {
 	storageFilter, err := storageFilter(filter, eventStore)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	logg.Debug("hermes.GetEvents: tenant id is %s", tenantID)
-	eventDetails, total, err := eventStore.GetEvents(storageFilter, tenantID)
+	eventDetails, total, err := eventStore.GetEvents(ctx, storageFilter, tenantID)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -162,20 +163,20 @@ func eventsList(eventDetails []*cadf.Event, details bool) ([]*ListEvent, error) 
 }
 
 // GetEvent returns the CADF detail for event with the specified ID
-func GetEvent(eventID, tenantID string, eventStore storage.Storage) (*cadf.Event, error) {
-	event, err := eventStore.GetEvent(eventID, tenantID)
+func GetEvent(ctx context.Context, eventID, tenantID string, eventStore storage.Storage) (*cadf.Event, error) {
+	event, err := eventStore.GetEvent(ctx, eventID, tenantID)
 
 	return event, err
 }
 
 // GetAttributes No Logic here, but handles mock implementation for eventStore
-func GetAttributes(filter *AttributeFilter, tenantID string, eventStore storage.Storage) ([]string, error) {
+func GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string, eventStore storage.Storage) ([]string, error) {
 	attributeFilter := storage.AttributeFilter{
 		QueryName: filter.QueryName,
 		MaxDepth:  filter.MaxDepth,
 		Limit:     filter.Limit,
 	}
-	attribute, err := eventStore.GetAttributes(&attributeFilter, tenantID)
+	attribute, err := eventStore.GetAttributes(ctx, &attributeFilter, tenantID)
 
 	return attribute, err
 }

--- a/pkg/hermes/events_test.go
+++ b/pkg/hermes/events_test.go
@@ -4,6 +4,7 @@
 package hermes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 
 func Test_GetEvent(t *testing.T) {
 	eventID := "7be6c4ff-b761-5f1f-b234-f5d41616c2cd"
-	event, err := GetEvent(eventID, "", storage.Mock{})
+	event, err := GetEvent(context.Background(), eventID, "", storage.Mock{})
 	require.Nil(t, err)
 	require.NotNil(t, event)
 	assert.Equal(t, "7be6c4ff-b761-5f1f-b234-f5d41616c2cd", event.ID)
@@ -24,7 +25,7 @@ func Test_GetEvent(t *testing.T) {
 }
 
 func Test_GetEvents(t *testing.T) {
-	events, total, err := GetEvents(&EventFilter{}, "", storage.Mock{})
+	events, total, err := GetEvents(context.Background(), &EventFilter{}, "", storage.Mock{})
 	require.Nil(t, err)
 	require.NotNil(t, events)
 	assert.Equal(t, len(events), 4)
@@ -42,7 +43,7 @@ func Test_GetEvents(t *testing.T) {
 }
 
 func Test_GetAttributes(t *testing.T) {
-	attributes, err := GetAttributes(&AttributeFilter{}, "", storage.Mock{})
+	attributes, err := GetAttributes(context.Background(), &AttributeFilter{}, "", storage.Mock{})
 	require.Nil(t, err)
 	require.NotNil(t, attributes)
 	assert.Equal(t, len(attributes), 6)

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -4,6 +4,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/sapcc/go-api-declarations/cadf"
 )
 
@@ -48,9 +50,9 @@ type Response struct {
 // Because it is an interface, the real implementation can be mocked away in unit tests.
 type Storage interface {
 	/********** requests to ElasticSearch **********/
-	GetEvents(filter *EventFilter, tenantID string) ([]*cadf.Event, int, error)
-	GetEvent(eventID, tenantID string) (*cadf.Event, error)
-	GetAttributes(filter *AttributeFilter, tenantID string) ([]string, error)
+	GetEvents(ctx context.Context, filter *EventFilter, tenantID string) ([]*cadf.Event, int, error)
+	GetEvent(ctx context.Context, eventID, tenantID string) (*cadf.Event, error)
+	GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string) ([]string, error)
 	MaxLimit() uint
 }
 

--- a/pkg/storage/mock.go
+++ b/pkg/storage/mock.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/sapcc/go-api-declarations/cadf"
@@ -13,7 +14,7 @@ import (
 type Mock struct{}
 
 // GetEvents mock with static data
-func (m Mock) GetEvents(filter *EventFilter, tenantID string) ([]*cadf.Event, int, error) {
+func (m Mock) GetEvents(ctx context.Context, filter *EventFilter, tenantID string) ([]*cadf.Event, int, error) {
 	var detailedEvents eventListWithTotal
 	err := json.Unmarshal(mockEvents, &detailedEvents)
 	if err != nil {
@@ -30,7 +31,7 @@ func (m Mock) GetEvents(filter *EventFilter, tenantID string) ([]*cadf.Event, in
 }
 
 // GetEvent Mock with static data
-func (m Mock) GetEvent(eventID, tenantID string) (*cadf.Event, error) {
+func (m Mock) GetEvent(ctx context.Context, eventID, tenantID string) (*cadf.Event, error) {
 	var parsedEvent cadf.Event
 	err := json.Unmarshal(mockEvent, &parsedEvent)
 	return &parsedEvent, err
@@ -42,7 +43,7 @@ func (m Mock) MaxLimit() uint {
 }
 
 // GetAttributes Mock
-func (m Mock) GetAttributes(filter *AttributeFilter, tenantID string) ([]string, error) {
+func (m Mock) GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string) ([]string, error) {
 	var parsedAttribute []string
 	err := json.Unmarshal(mockAttributes, &parsedAttribute)
 	return parsedAttribute, err

--- a/pkg/storage/mock_test.go
+++ b/pkg/storage/mock_test.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sapcc/go-api-declarations/cadf"
@@ -12,7 +13,7 @@ import (
 
 func Test_MockStorage_EventDetail(t *testing.T) {
 	// both params are ignored
-	eventDetail, err := Mock{}.GetEvent("d5eed458-6666-58ec-ad06-8d3cf6bafca1", "b3b70c8271a845709f9a03030e705da7")
+	eventDetail, err := Mock{}.GetEvent(context.Background(), "d5eed458-6666-58ec-ad06-8d3cf6bafca1", "b3b70c8271a845709f9a03030e705da7")
 	assert.Nil(t, err)
 	tt := []struct {
 		name     string
@@ -39,7 +40,7 @@ func Test_MockStorage_EventDetail(t *testing.T) {
 }
 
 func Test_MockStorage_Events(t *testing.T) {
-	eventsList, total, err := Mock{}.GetEvents(&EventFilter{}, "b3b70c8271a845709f9a03030e705da7")
+	eventsList, total, err := Mock{}.GetEvents(context.Background(), &EventFilter{}, "b3b70c8271a845709f9a03030e705da7")
 
 	assert.Nil(t, err)
 	assert.Equal(t, total, 4)
@@ -50,7 +51,7 @@ func Test_MockStorage_Events(t *testing.T) {
 }
 
 func Test_MockStorage__Attributes(t *testing.T) {
-	attributesList, err := Mock{}.GetAttributes(&AttributeFilter{}, "b3b70c8271a845709f9a03030e705da7")
+	attributesList, err := Mock{}.GetAttributes(context.Background(), &AttributeFilter{}, "b3b70c8271a845709f9a03030e705da7")
 
 	assert.Nil(t, err)
 	assert.Equal(t, len(attributesList), 6)


### PR DESCRIPTION
Update Storage interface to accept context.Context and thread it from HTTP handlers to Opensearch queries. 

Enables request cancellation when clients disconnect. This prevents wasted Opensearch queries which is particularly important with us moving to a single index. 

This is prepping for a PR to implement single index support. 