### PR TITLE
bump Go to 1.27

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
   ],
   "commitMessageAction": "Renovate: Update",
   "constraints": {
-    "go": "1.26"
+    "go": "1.27"
   },
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "osvVulnerabilityAlerts": true,

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,11 +31,11 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.6
+          go-version: 1.27.0
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v2.13.1
       - name: Delete pre-installed shellcheck
         run: sudo rm -f "$(which shellcheck)"
       - name: Run shellcheck

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.6
+          go-version: 1.27.0
       - name: Build all binaries
         run: make build-all
   code_coverage:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.6
+          go-version: 1.27.0
       - name: Run tests and generate coverage report
         run: |
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           check-latest: true
-          go-version: 1.26.6
+          go-version: 1.27.0
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -161,6 +161,10 @@ linters:
       enable-all: true
     nolintlint:
       require-specific: true
+    modernize:
+      disable:
+        # embedlit is new in Go 1.27 and triggers in a ton of places. We will enable this once Go 1.27 has settled a bit. (TODO: revisit this in a few weeks)
+        - embedlit
     perfsprint:
       # modernize generates nicer fix code
       concat-loop: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company
 # SPDX-License-Identifier: Apache-2.0
 
-ARG IMAGE=golang:1.26.6-alpine3.24
+ARG IMAGE=golang:1.27.0-alpine3.24
 
 FROM $IMAGE AS builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/hermes
 
-go 1.26
+go 1.27
 
 require (
 	github.com/databus23/goslo.policy v0.0.0-20250326134918-4afc2c56a903

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -13,8 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/sapcc/go-bits/errext"

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ mkShell {
   nativeBuildInputs = [
     addlicense
     go-licence-detector
-    go_1_26
+    go_1_27
     golangci-lint
     gotools # goimports
     postgresql_18


### PR DESCRIPTION
Manual intervention is required because the golangci-lint configuration generated by go-makefile-maker now flags usage of the deprecated package `github.com/google/uuid`. Go 1.27 includes a `uuid` package in std, where `uuid.Parse()` accepts the same range of formats according to my reading of the documentation on both sides.