### PR TITLE
let cloud admins manage dataplane-config cross-project

### DIFF
--- a/etc/policy.json
+++ b/etc/policy.json
@@ -9,5 +9,5 @@
 
   "event:list":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
   "event:show":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
-  "dataplane_config:manage":  "rule:project_admin"
+  "dataplane_config:manage":  "rule:project_admin or rule:cluster_viewer"
 }

--- a/pkg/api/dataplane_config.go
+++ b/pkg/api/dataplane_config.go
@@ -223,9 +223,13 @@ func (p *v1Provider) authDataplaneConfig(res http.ResponseWriter, req *http.Requ
 		return nil, false
 	}
 
-	// Cross-project access check: path project_id must match the token scope.
+	// Cross-project access check: the path project_id must match the token
+	// scope, unless the caller is a cloud admin (cluster_viewer). This mirrors
+	// the cross-project override in events.go (getIndexID), letting operators
+	// manage dataplane config on a tenant's behalf. token.Check does not write
+	// a response, so we emit the 403 ourselves.
 	tokenProjectID := token.Context.Auth["project_id"]
-	if tokenProjectID != pathProjectID {
+	if tokenProjectID != pathProjectID && !token.Check("cluster_viewer") {
 		http.Error(res, "project_id in path does not match token scope", http.StatusForbidden)
 		return nil, false
 	}

--- a/pkg/api/dataplane_config_test.go
+++ b/pkg/api/dataplane_config_test.go
@@ -8,14 +8,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strconv"
 	"testing"
 	"time"
 
-	policy "github.com/databus23/goslo.policy"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/viper"
 
 	"github.com/sapcc/go-api-declarations/cadf"
 	"github.com/sapcc/go-bits/audittools"
@@ -93,22 +90,20 @@ func payloadAttachment(enabled bool, targetBucket string) []cadf.Attachment {
 // Returns the handler, the routing mock store, and the mock auditor for event assertions.
 func setupDataplaneTest(t *testing.T) (http.Handler, *routing.Mock, *audittools.MockAuditor) {
 	t.Helper()
+	return setupDataplaneTestForbidding(t)
+}
 
-	policyBytes, err := os.ReadFile("../test/policy.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	policyRules := make(map[string]string)
-	if err := json.Unmarshal(policyBytes, &policyRules); err != nil {
-		t.Fatal(err)
-	}
-	policyEnforcer, err := policy.NewEnforcer(policyRules)
-	if err != nil {
-		t.Fatal(err)
-	}
-	viper.Set("hermes.PolicyEnforcer", policyEnforcer)
+// setupDataplaneTestForbidding is like setupDataplaneTest but forbids the given
+// policy rules on the mock enforcer (which allows everything by default). Use it
+// to deny cluster_viewer and exercise the cross-project 403 path.
+func setupDataplaneTestForbidding(t *testing.T, forbiddenRules ...string) (http.Handler, *routing.Mock, *audittools.MockAuditor) {
+	t.Helper()
 
-	validator := mock.NewValidator(mock.NewEnforcer(), map[string]string{
+	enforcer := mock.NewEnforcer()
+	for _, rule := range forbiddenRules {
+		enforcer.Forbid(rule)
+	}
+	validator := mock.NewValidator(enforcer, map[string]string{
 		"project_id": testProjectID,
 		"user_id":    "user-abc",
 	})
@@ -326,9 +321,10 @@ func TestDataplaneConfig_DeleteNonExistent(t *testing.T) {
 }
 
 // TestDataplaneConfig_CrossProjectForbidden proves that a token scoped to
-// testProjectID cannot access a different project's config (403).
+// testProjectID that is NOT a cloud admin cannot access a different project's
+// config (403). cluster_viewer is explicitly denied here.
 func TestDataplaneConfig_CrossProjectForbidden(t *testing.T) {
-	handler, _, auditor := setupDataplaneTest(t) // token project_id = testProjectID
+	handler, _, auditor := setupDataplaneTestForbidding(t, "cluster_viewer") // deny cloud-admin bypass; token project_id = testProjectID
 
 	differentProject := "other-project-99"
 	otherPath := "/v1/projects/" + differentProject + "/dataplane-config"
@@ -361,6 +357,38 @@ func TestDataplaneConfig_CrossProjectForbidden(t *testing.T) {
 
 	// 403 happens before the handler body runs — no audit events from our code.
 	auditor.ExpectEvents(t /* none */)
+}
+
+// TestDataplaneConfig_CrossProjectCloudAdmin proves that a cloud admin
+// (cluster_viewer satisfied) CAN manage a different project's config, writing
+// to the path project. This mirrors the cross-project override in events.go.
+func TestDataplaneConfig_CrossProjectCloudAdmin(t *testing.T) {
+	handler, store, _ := setupDataplaneTestForbidding(t) // cluster_viewer allowed by default; token project_id = testProjectID
+
+	differentProject := "other-project-99"
+	otherPath := "/v1/projects/" + differentProject + "/dataplane-config"
+
+	putBody, err := json.Marshal(map[string]any{"enabled": true, "target_bucket": "hermes-audit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	putReq := httptest.NewRequest(http.MethodPut, otherPath, bytes.NewReader(putBody))
+	putReq.Header.Set("X-Auth-Token", "something")
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	handler.ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("cloud-admin PUT to different project: expected 200, got %d: %s", putRec.Code, putRec.Body.String())
+	}
+
+	// The config must be written under the PATH project, not the token's project.
+	cfg, err := store.Get(putReq.Context(), differentProject)
+	if err != nil {
+		t.Fatalf("expected config for %s, got error: %s", differentProject, err)
+	}
+	if !cfg.Enabled || cfg.TargetBucket != "hermes-audit" {
+		t.Errorf("unexpected saved config: %+v", cfg)
+	}
 }
 
 // TestDataplaneConfig_DisabledPutAcceptsEmptyBucket proves PUT with enabled=false


### PR DESCRIPTION
Operators currently can't enable/disable a tenant's dataplane routing unless they hold `audit_admin` scoped to that exact project — the handler hard-required token project == path project.

This mirrors the existing `cluster_viewer` cross-project override in `events.go` (`getIndexID`): a cloud admin may now target any project's dataplane-config; everyone else still gets 403.

- `policy.json`: `dataplane_config:manage` = `rule:project_admin or rule:cluster_viewer`
- `authDataplaneConfig`: allow cross-project when `cluster_viewer` passes (via `token.Check`, no double-write)
- tests: negative path (cluster_viewer denied → 403) kept; added positive path (cloud admin → 200, writes to the path project)

`go test ./...` green.